### PR TITLE
I feel the need for "other" errors

### DIFF
--- a/wheb-base/src/Web/Wheb/Plugins/Auth.hs
+++ b/wheb-base/src/Web/Wheb/Plugins/Auth.hs
@@ -98,6 +98,7 @@ type Password = Text
 type PwHash = Text
 
 data AuthError = DuplicateUsername | UserDoesNotExist | InvalidPassword
+              |  InternalError
   deriving (Show)
 
 data AuthUser = AuthUser { uniqueUserKey :: UserKey } deriving (Show)


### PR DESCRIPTION
There are so many backend errors that can happen that don't map to the existing errors.

Alternative an (InternalError Text) could be useful.